### PR TITLE
Port upstream hdl-util/hdmi PR #44: fix HDMI control period and timin…

### DIFF
--- a/hdl/hdmi/hdmi.sv
+++ b/hdl/hdmi/hdmi.sv
@@ -192,9 +192,9 @@ always_comb begin
     hsync <= invert ^ (cx >= screen_width + hsync_pulse_start && cx < screen_width + hsync_pulse_start + hsync_pulse_size);
     // vsync pulses should begin and end at the start of hsync, so special
     // handling is required for the lines on which vsync starts and ends
-    if (cy == screen_height + vsync_pulse_start)
+    if (cy == screen_height + vsync_pulse_start - 1)
         vsync <= invert ^ (cx >= screen_width + hsync_pulse_start);
-    else if (cy == screen_height + vsync_pulse_start + vsync_pulse_size)
+    else if (cy == screen_height + vsync_pulse_start + vsync_pulse_size - 1)
         vsync <= invert ^ (cx < screen_width + hsync_pulse_start);
     else
         vsync <= invert ^ (cy >= screen_height + vsync_pulse_start && cy < screen_height + vsync_pulse_start + vsync_pulse_size);
@@ -254,8 +254,8 @@ generate
             end
             else
             begin
-                video_guard <= cx >= frame_width - 2 && cx < frame_width && (cy == frame_height - 1 || cy < screen_height);
-                video_preamble <= cx >= frame_width - 10 && cx < frame_width - 2 && (cy == frame_height - 1 || cy < screen_height);
+                video_guard <= cx >= frame_width - 2 && cx < frame_width && (cy == frame_height - 1 || cy < screen_height - 1);
+                video_preamble <= cx >= frame_width - 10 && cx < frame_width - 2 && (cy == frame_height - 1 || cy < screen_height - 1);
             end
         end
 
@@ -264,7 +264,7 @@ generate
         logic [4:0] num_packets_alongside;
         always_comb
         begin
-            max_num_packets_alongside = ((frame_width - screen_width) /* VD period */ - 2 /* V guard */ - 8 /* V preamble */ - 12 /* 12px control period */ - 2 /* DI guard */ - 2 /* DI start guard */ - 8 /* DI premable */) / 32;
+            max_num_packets_alongside = (frame_width - screen_width /* VD period */ - 2 /* V guard */ - 8 /* V preamble */ - 4 /* Min V control period */ - 2 /* DI trailing guard */ - 2 /* DI leading guard */ - 8 /* DI preamble */ - 4 /* Min DI control period */) / 32;
             if (max_num_packets_alongside > 18)
                 num_packets_alongside = 5'd18;
             else
@@ -272,9 +272,9 @@ generate
         end
 
         logic data_island_period_instantaneous;
-        assign data_island_period_instantaneous = num_packets_alongside > 0 && cx >= screen_width + 10 && cx < screen_width + 10 + num_packets_alongside * 32;
+        assign data_island_period_instantaneous = num_packets_alongside > 0 && cx >= screen_width + 14 && cx < screen_width + 14 + num_packets_alongside * 32;
         logic packet_enable;
-        assign packet_enable = data_island_period_instantaneous && 5'(cx + screen_width + 22) == 5'd0;
+        assign packet_enable = data_island_period_instantaneous && 5'(cx + screen_width + 18) == 5'd0;
 
         logic data_island_guard = 0;
         logic data_island_preamble = 0;
@@ -289,8 +289,8 @@ generate
             end
             else
             begin
-                data_island_guard <= num_packets_alongside > 0 && ((cx >= screen_width + 8 && cx < screen_width + 10) || (cx >= screen_width + 10 + num_packets_alongside * 32 && cx < screen_width + 10 + num_packets_alongside * 32 + 2));
-                data_island_preamble <= num_packets_alongside > 0 && cx >= screen_width && cx < screen_width + 8;
+                data_island_guard <= num_packets_alongside > 0 && ((cx >= screen_width + 12 && cx < screen_width + 14) || (cx >= screen_width + 14 + num_packets_alongside * 32 && cx < screen_width + 14 + num_packets_alongside * 32 + 2));
+                data_island_preamble <= num_packets_alongside > 0 && cx >= screen_width + 4 && cx < screen_width + 12;
                 data_island_period <= data_island_period_instantaneous;
             end
         end
@@ -321,7 +321,7 @@ generate
             begin
                 mode <= 3'd2;
                 video_data <= 24'd0;
-                control_data = 6'd0;
+                control_data <= 6'd0;
                 data_island_data <= 12'd0;
             end
             else


### PR DESCRIPTION
Ports fixes from upstream hdl-util/hdmi PR #44 (merged Aug 2023) that were never applied to this codebase. These fix HDMI spec violations that could cause sinks to reject the signal in HDMI mode:

1. VSync off-by-one: vsync pulse start/end comparisons were off by one scan line, causing vsync transitions to be delayed by a line.

2. Video guard/preamble on last active line: VG and VP were generated at the end of the last active video line (cy == screen_height - 1), causing them to overlap with the data island period on that line. Now excluded (cy < screen_height - 1).

3. Minimum control period (HDMI spec Section 5.2.5.3): The original code had ZERO control period pixels between end of active video and start of data island preamble. The fix shifts data island signals +4 pixels later, creating proper 4px minimum control periods both before the DI preamble and before the video preamble.

4. Max packets formula: corrected accounting for two 4px minimum control periods instead of one 12px period.

5. Blocking assignment fix: control_data used blocking assignment (=) in a sequential always_ff block; changed to non-blocking (<=).

Reference: https://github.com/hdl-util/hdmi/pull/44
https://claude.ai/code/session_015tYrATpPNxSHeS9bnZfqjz