### PR TITLE
Fix expansion ROM and bus timing bugs for multi-card emulation

### DIFF
--- a/boards/a2n20v2-Enhanced/hdl/memory/apple_memory.sv
+++ b/boards/a2n20v2-Enhanced/hdl/memory/apple_memory.sv
@@ -142,7 +142,10 @@ module apple_memory #(
             INTC8ROM <= 1'b0;
             SLOTROM <= 3'b0;
         end else if ((a2bus_if.phi1_posedge) && (a2bus_if.addr >= 16'hC100) && (a2bus_if.addr < 16'hC800) && !a2bus_if.m2sel_n) begin
-            if (!a2mem_if.SLOTC3ROM && (a2bus_if.addr[15:8] == 8'hC3)) INTC8ROM <= 1'b1; // Slot C3 ROM  
+            if (!a2mem_if.SLOTC3ROM && (a2bus_if.addr[15:8] == 8'hC3))
+                INTC8ROM <= 1'b1;
+            else
+                INTC8ROM <= 1'b0;  // Clear on non-C3 slot access (real IIe behavior)
             SLOTROM <= a2bus_if.addr[10:8];
         end
     end

--- a/hdl/memory/apple_memory.sv
+++ b/hdl/memory/apple_memory.sv
@@ -69,6 +69,18 @@ module apple_memory #(
     reg [2:0] SLOTROM;
     assign a2mem_if.SLOTROM = SLOTROM;
 
+    // Runtime Apple ][+ vs IIe detection: the IIe boot ROM writes to $C00x
+    // soft switches within milliseconds of startup. A ][+ never touches these
+    // addresses. Used to gate IIe-only INTC8ROM logic.
+    reg is_iie;
+    always @(posedge a2bus_if.clk_logic or negedge a2bus_if.system_reset_n) begin
+        if (!a2bus_if.system_reset_n)
+            is_iie <= 1'b0;
+        else if (!a2bus_if.rw_n && (a2bus_if.phi1_posedge) &&
+                 (a2bus_if.addr[15:4] == 12'hC00) && !a2bus_if.m2sel_n)
+            is_iie <= 1'b1;
+    end
+
     // capture the soft switches
     always @(posedge a2bus_if.clk_logic or negedge a2bus_if.system_reset_n) begin
         if (!a2bus_if.system_reset_n) begin
@@ -138,7 +150,14 @@ module apple_memory #(
             INTC8ROM <= 1'b0;
             SLOTROM <= 3'b0;
         end else if ((a2bus_if.phi1_posedge) && (a2bus_if.addr >= 16'hC100) && (a2bus_if.addr < 16'hC800) && !a2bus_if.m2sel_n) begin
-            if (!a2mem_if.SLOTC3ROM && (a2bus_if.addr[15:8] == 8'hC3)) INTC8ROM <= 1'b1; // Slot C3 ROM  
+            // INTC8ROM is IIe-only: routes $C800-$CFFF to internal 80-col firmware.
+            // On ][+, SLOTC3ROM doesn't exist (defaults to 0), so without the is_iie
+            // guard, INTC8ROM would be permanently set after any $C3xx access, blocking
+            // io_strobe_n for ALL cards' expansion ROM reads.
+            if (is_iie && !a2mem_if.SLOTC3ROM && (a2bus_if.addr[15:8] == 8'hC3))
+                INTC8ROM <= 1'b1;
+            else
+                INTC8ROM <= 1'b0;  // Clear on non-C3 slot access (real IIe behavior)
             SLOTROM <= a2bus_if.addr[10:8];
         end
     end

--- a/hdl/ssc/super_serial_card.sv
+++ b/hdl/ssc/super_serial_card.sv
@@ -117,7 +117,7 @@ module SuperSerial #(
     always @(posedge a2bus_if.clk_logic) begin
         if (!a2bus_if.system_reset_n) begin
             C8S2 <= 1'b0;
-        end else begin
+        end else if (a2bus_if.phi0) begin
             case (a2bus_if.addr[15:8])
                 8'hC2: begin
                     if (!a2mem_if.INTCXROM)  // SSC ROM
@@ -132,7 +132,8 @@ module SuperSerial #(
         end
     end
 
-    assign ENA_C8S  = {(C8S2 & !a2mem_if.INTCXROM), a2bus_if.addr[15:11]} == 6'b111001;
+    assign ENA_C8S  = {(C8S2 & !a2mem_if.INTCXROM), a2bus_if.addr[15:11]} == 6'b111001
+                     && (a2mem_if.SLOTROM == 3'd2);
     assign rom_en_o = ENA_C8S;
     //assign data_o2 = ENA_C8S ? DOA_C8S : SSC;
 


### PR DESCRIPTION
## Summary

Two latent bugs in the expansion ROM ownership logic that are exposed when multiple
emulated cards with C8 expansion ROM are active simultaneously, or when physical Apple II
cards with C8 ROMs share the CPLD bus.

### Fix 1: INTC8ROM permanently blocking expansion ROM on Apple ][+

**Files:** `hdl/memory/apple_memory.sv`, `boards/a2n20v2-Enhanced/hdl/memory/apple_memory.sv`

On Apple ][+, the `SLOTC3ROM` soft switch doesn't exist (IIe-only) and defaults to 0. The
existing code unconditionally sets `INTC8ROM=1` on every `$C3xx` access when `SLOTC3ROM=0`.
Since `INTC8ROM=1` blocks `io_strobe_n` generation in the slotmaker framework, **ALL**
emulated cards' expansion ROM reads stop working — not just the card in slot 3.

This is latent because upstream slot 3 is typically empty. Any card assigned to slot 3 on a
][+ exposes the bug.

**Fix:** Add runtime ][+ vs IIe detection (`is_iie` flag). The IIe boot ROM writes to `$C00x`
soft switches within milliseconds of startup; a ][+ never does. Gate INTC8ROM with `is_iie`
and add missing `else` clause to clear INTC8ROM on non-C3 slot access (real IIe behavior).

### Fix 2: SSC expansion ROM phi0 qualification and SLOTROM guard

**File:** `hdl/ssc/super_serial_card.sv`

Two issues in SSC's C8-space ownership logic:

1. **Missing phi0 gate on C8S2:** When other cards sharing the CPLD transition their `rd_en_o`
   from active to tristate, PCB bus transceiver glitches create address transients visible to
   the FPGA at 54 MHz. Without phi0 qualification, the SSC's `$CFFF` detection fires on these
   transients, spuriously clearing `C8S2` mid-execution of the SSC expansion ROM.

2. **Missing SLOTROM guard on ENA_C8S:** Once `C8S2` is set via `$C2xx`, the SSC responds to
   ALL `$C800-$CFFF` reads even when another slot should be active. On real hardware with
   per-slot bus transceivers this doesn't matter, but on the shared CPLD it causes bus
   contention.

Both bugs are latent because the SSC is the only upstream emulated card with C8 expansion ROM.
With only one C8-capable card, no other card's `rd_en_o` transitions create glitches, and stale
`C8S2` never causes contention. Adding any second C8-capable card (emulated or physical) exposes
both bugs.

## How Discovered

Found during Videx VideoTerm emulation development. Apple Pascal 1.3 boot hung
non-deterministically during SSC FINIT — the Videx card's bus transceiver transitions
cleared SSC's `C8S2` mid-execution, and stale `C8S2` caused the SSC to respond during
Videx's C8-space reads.

## Test Plan

- [x] Apple ][+ hardware test with emulated cards: SSC (slot 2), Videx (slot 3),
  Mockingboard (slot 4), SuperSprite (slot 7)
- [x] Apple Pascal 1.3 boots 100% with all cards enabled
- [x] PR#3 enters 80-column mode correctly (slot 3 access triggers INTC8ROM path)
- [x] Original Videx VideoTerm Demo application runs correctly
- [x] SSC expansion ROM accessible when SLOTROM=2, correctly inhibited for other slots