### PR TITLE
Add early OE cutoff for CPLD bus data output enable

### DIFF
--- a/boards/a2n20v2-Enhanced/hdl/bus/apple_bus.sv
+++ b/boards/a2n20v2-Enhanced/hdl/bus/apple_bus.sv
@@ -299,7 +299,25 @@ module apple_bus #(
 
     end
 
-    assign a2_bridge_bus_d_oe_n_o = ~(data_out_en_i & BUS_DATA_OUT_ENABLE);
+    // Early OE cutoff: Release bus transceiver before CDC-delayed phi0 drop.
+    //
+    // The CDC denoise pipeline delays phi0 by ~CDC_DELAY clk_logic cycles
+    // (~100ns at 54 MHz). Without cutoff, the CPLD bus driver stays active
+    // for the full CDC delay into phi1, creating ~100ns of bus contention
+    // when the 6502 is already in its next cycle. A real slot card's 74LS245
+    // releases within ~10-20ns of phi0 dropping.
+    //
+    // The phase counter resets on each CDC-delayed phi edge. Real phi0 drops
+    // at approximately PHASE_COUNT - CDC_DELAY counts into the phi0 half.
+    // OE_CUTOFF fires at cycle 22, approximately 37ns after the estimated
+    // real phi0 drop. IO_WRITE_DATA triggers at cycle 10 and completes by
+    // cycle 13, so all card data is latched well before cutoff.
+    localparam int CDC_DELAY = 6;   // CDC denoise: 2 sync + 3 debounce + 1 FIFO
+    localparam int OE_MARGIN = 2;   // Cycles past estimated real phi0 drop
+    localparam int OE_CUTOFF = PHASE_COUNT - CDC_DELAY + OE_MARGIN;  // = 22
+
+    wire oe_early_cutoff = a2bus_if.phi0 && (phase_cycles_r >= OE_CUTOFF[5:0]);
+    assign a2_bridge_bus_d_oe_n_o = ~(data_out_en_i & BUS_DATA_OUT_ENABLE & ~oe_early_cutoff);
 
     assign a2bus_if.data_in_strobe = data_in_strobe_r;
 

--- a/boards/a2n20v2/hdl/bus/apple_bus.sv
+++ b/boards/a2n20v2/hdl/bus/apple_bus.sv
@@ -288,7 +288,25 @@ module apple_bus #(
 
     end
 
-    assign a2_bridge_bus_d_oe_n_o = ~(data_out_en_i & BUS_DATA_OUT_ENABLE);
+    // Early OE cutoff: Release bus transceiver before CDC-delayed phi0 drop.
+    //
+    // The CDC denoise pipeline delays phi0 by ~CDC_DELAY clk_logic cycles
+    // (~100ns at 54 MHz). Without cutoff, the CPLD bus driver stays active
+    // for the full CDC delay into phi1, creating ~100ns of bus contention
+    // when the 6502 is already in its next cycle. A real slot card's 74LS245
+    // releases within ~10-20ns of phi0 dropping.
+    //
+    // The phase counter resets on each CDC-delayed phi edge. Real phi0 drops
+    // at approximately PHASE_COUNT - CDC_DELAY counts into the phi0 half.
+    // OE_CUTOFF fires at cycle 22, approximately 37ns after the estimated
+    // real phi0 drop. IO_WRITE_DATA triggers at cycle 10 and completes by
+    // cycle 13, so all card data is latched well before cutoff.
+    localparam int CDC_DELAY = 6;   // CDC denoise: 2 sync + 3 debounce + 1 FIFO
+    localparam int OE_MARGIN = 2;   // Cycles past estimated real phi0 drop
+    localparam int OE_CUTOFF = PHASE_COUNT - CDC_DELAY + OE_MARGIN;  // = 22
+
+    wire oe_early_cutoff = a2bus_if.phi0 && (phase_cycles_r >= OE_CUTOFF[5:0]);
+    assign a2_bridge_bus_d_oe_n_o = ~(data_out_en_i & BUS_DATA_OUT_ENABLE & ~oe_early_cutoff);
 
     assign a2bus_if.data_in_strobe = data_in_strobe_r;
 


### PR DESCRIPTION
## Summary

**Files:** `boards/a2n20v2/hdl/bus/apple_bus.sv`, `boards/a2n20v2-Enhanced/hdl/bus/apple_bus.sv`

The CDC denoise pipeline (2-stage sync + 3-bit debounce + FIFO) delays phi0 by ~6 `clk_logic`
cycles (~100ns at 54 MHz). The CPLD bus data output enable (`a2_bridge_bus_d_oe_n_o`) is purely
combinational, tracking `data_out_en_i`. When cards deassert `rd_en_o` at the real phi0 falling
edge, the CPLD OE doesn't release until the CDC-delayed phi0 drop reaches the FPGA — creating
~100ns of bus contention where the CPLD continues driving the Apple II data bus while the 6502
is already in its next cycle. A real slot card's 74LS245 releases within ~10-20ns of phi0
dropping.

This ~100ns overlap is especially harmful during I/O write cycles (`$C0xx`) that originate from
expansion ROM (`$C800-$CFFF`) instruction fetches. The Apple II motherboard's I/O decode logic
responds with timing sensitive to bus contention. Binary search via ROM patching confirmed: I/O
writes from C8 space break disk loading; main RAM writes from C8 space work fine.

### Why registering OE doesn't work

Hardware-tested: registering `a2_bridge_bus_d_oe_n_o` causes Apple II resets. The 1-cycle
delay extends CPLD drive INTO phi1, creating bus contention with the 6502 that is worse than
the ~100ns overlap.

### The fix

Use the existing phase counter (`phase_cycles_r`) to force-release OE before the CDC-delayed
phi0 drop. Real phi0 drops at approximately `PHASE_COUNT - CDC_DELAY` (= 20) counts. The
cutoff fires at cycle 22 (`OE_MARGIN=2`), ~37ns after the estimated real phi0 drop.
`IO_WRITE_DATA` triggers at cycle 10 and completes by cycle 13, so all card data is latched
well before cutoff.

This reduces the contention window from ~100ns to ~37ns. The margin parameters (`OE_MARGIN`)
can be tuned if needed: increase to 3-4 if cards fail to respond, decrease to 1 if more
aggressive cutoff is needed.

Only applies to CPLD-based boards (a2n20v2, a2n20v2-Enhanced). The a2mega board has direct bus
access and is not affected.

## How Discovered

Found during Apple Pascal 1.3 boot testing with Videx VideoTerm (slot 3) and SSC (slot 2)
emulated cards. Both perform I/O writes during FINIT routines from C8 expansion ROM. Pascal
boot hung deterministically at the disk load phase. The root cause was isolated through ROM
patch binary search: replacing C8-space I/O writes with main RAM writes eliminated the hang.

The bug is latent: the ~100ns OE extension exists on every bus read cycle, but only causes
failures when multiple cards with C8 expansion ROM are active. With only the SSC (the only
upstream card with C8 ROM), the timing margin is sufficient. Adding any second C8-capable
card increases bus activity and OE transitions, narrowing the margin past the failure
threshold. Physical Apple II cards with C8 ROMs sharing the CPLD bus would also be affected.

## Test Plan

- [x] Apple ][+ hardware test with all emulated cards: SSC, Videx, Mockingboard, SuperSprite
- [x] Apple Pascal 1.3 boots 100% (was deterministic hang before fix)
- [x] Original Videx VideoTerm Demo application runs correctly
- [x] No regression in card bus response timing
- [ ] a2n20v2-Enhanced board test (identical fix applied, not hardware-tested yet)