### PR TITLE
Fix HDMI sink compatibility for Samsung TVs and strict monitors

### DIFF
--- a/hdl/hdmi/audio_clock_regeneration_packet.sv
+++ b/hdl/hdmi/audio_clock_regeneration_packet.sv
@@ -57,11 +57,8 @@ begin
 end
 
 // "An HDMI Sink shall ignore bytes HB1 and HB2 of the Audio Clock Regeneration Packet header."
-`ifdef MODEL_TECH
+// Use deterministic zero values so BCH ECC is consistent in synthesis.
 assign header = {8'd0, 8'd0, 8'd1};
-`else
-assign header = {8'dX, 8'dX, 8'd1};
-`endif
 
 // "The four Subpackets each contain the same Audio Clock regeneration Subpacket."
 genvar i;

--- a/hdl/hdmi/hdmi.sv
+++ b/hdl/hdmi/hdmi.sv
@@ -321,7 +321,7 @@ generate
             begin
                 mode <= 3'd2;
                 video_data <= 24'd0;
-                control_data = 6'd0;
+                control_data <= 6'd0;
                 data_island_data <= 12'd0;
             end
             else

--- a/hdl/hdmi/packet_picker.sv
+++ b/hdl/hdmi/packet_picker.sv
@@ -36,15 +36,9 @@ assign sub[3] = subs[packet_type][3];
 
 // NULL packet
 // "An HDMI Sink shall ignore bytes HB1 and HB2 of the Null Packet Header and all bytes of the Null Packet Body."
-`ifdef MODEL_TECH
-assign headers[0] = {8'd0, 8'd0, 8'd0}; assign subs[0] = '{56'd0, 56'd0, 56'd0, 56'd0};
-`else
-assign headers[0] = {8'dX, 8'dX, 8'd0};
-assign subs[0][0] = 56'dX;
-assign subs[0][1] = 56'dX;
-assign subs[0][2] = 56'dX;
-assign subs[0][3] = 56'dX;
-`endif
+// Use deterministic zero values so BCH ECC is consistent in synthesis.
+assign headers[0] = {8'd0, 8'd0, 8'd0};
+assign subs[0] = '{56'd0, 56'd0, 56'd0, 56'd0};
 
 // Audio Clock Regeneration Packet
 logic clk_audio_counter_wrap;
@@ -135,7 +129,19 @@ audio_sample_packet #(.SAMPLING_FREQUENCY(SAMPLING_FREQUENCY), .WORD_LENGTH({{WO
 
 auxiliary_video_information_info_frame #(
     .VIDEO_ID_CODE(7'(VIDEO_ID_CODE)),
-    .IT_CONTENT(IT_CONTENT)
+    .IT_CONTENT(IT_CONTENT),
+    // CTA-861 requires PICTURE_ASPECT_RATIO to match the VIC.
+    // VIC 2 = 4:3, VIC 3 = 16:9.  Leaving this at "no data" (2'b00)
+    // caused some HDMI sinks (e.g. Ingnok) to reject the signal.
+    .PICTURE_ASPECT_RATIO(VIDEO_ID_CODE == 3 ? 2'b10 : 2'b01),
+    // Samsung TVs require ACTIVE_FORMAT_INFO_PRESENT=1 with R3-R0=1000
+    // ("same as coded frame") or they may reject the signal.
+    .ACTIVE_FORMAT_INFO_PRESENT(1'b1),
+    // Tell the sink this is underscan content (pixel-accurate, no overscan).
+    .SCAN_INFO(2'b10),
+    // Explicitly signal full-range RGB (0-255). Samsung TVs need this
+    // rather than relying on the IT_CONTENT flag to imply full range.
+    .RGB_QUANTIZATION_RANGE(2'b10)
 ) auxiliary_video_information_info_frame(.header(headers[130]), .sub(subs[130]));
 
 
@@ -160,7 +166,7 @@ begin
         audio_info_frame_sent <= 1'b0;
         auxiliary_video_information_info_frame_sent <= 1'b0;
         source_product_description_info_frame_sent <= 1'b0;
-        packet_type <= 8'dx;
+        packet_type <= 8'd0;
     end
     else if (packet_enable)
     begin


### PR DESCRIPTION
## Summary

**Files:** `hdl/hdmi/hdmi.sv`, `hdl/hdmi/audio_clock_regeneration_packet.sv`, `hdl/hdmi/packet_picker.sv`

Samsung TVs and some strict HDMI monitors (e.g. Ingnok portable displays) reject the A2FPGA
HDMI signal entirely, showing no video. The root cause is multiple HDMI spec violations in
the packet generation that lenient sinks tolerate but strict sinks reject.

### Fixes

- **AVI InfoFrame fields:** Set `PICTURE_ASPECT_RATIO` to match VIC, `ACTIVE_FORMAT_INFO_PRESENT=1`,
  `SCAN_INFO=underscan`, `RGB_QUANTIZATION_RANGE=full (0-255)` — instead of relying on defaults
  that some sinks interpret as "undefined"
- **Non-deterministic X values:** Replace `X` values in null packet and ACR headers with zeros
  so BCH ECC checksums are consistent across synthesis runs
- **Packet type reset:** Fix `packet_type` reset to `8'd0` (null) instead of `8'dx` for
  deterministic mux behavior between `field_end` and `packet_enable`
- **Blocking assignment fix:** Change `control_data` from blocking (`=`) to non-blocking (`<=`)
  assignment in HDMI mode reset path (sequential `always_ff` block)

## How Discovered

Testing A2FPGA output on a Samsung TV produced no video at all. The TV's HDMI input simply
showed "No Signal." Investigation revealed the packet generation had missing InfoFrame fields
and non-deterministic packet content that strict sinks rejected.

Note: This is a companion to PR #35 which addresses HDMI control period timing from the
upstream hdl-util/hdmi library. This PR fixes additional compatibility issues in the A2FPGA-
specific packet generation code.

## Test Plan

- [x] Samsung TV displays A2FPGA video correctly (was "No Signal" before fix)
- [x] Ingnok portable monitor displays correctly
- [x] No regression on previously-working HDMI sinks (Dell monitor, LG TV)